### PR TITLE
Remove unused dependency on listenfd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,7 +256,6 @@ dependencies = [
  "ctrlc 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "listenfd 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "maxminddb 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -598,16 +597,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "linked-hash-map"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "listenfd"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "lock_api"
@@ -1498,14 +1487,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "uuid"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "uuid"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1645,7 +1626,6 @@ dependencies = [
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)" = "2d2857ec59fadc0773853c664d2d18e7198e83883e7060b63c924cb077bd5c74"
 "checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
-"checksum listenfd 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "492158e732f2e2de81c592f0a2427e57e12cd3d59877378fe7af624b6bbe0ca1"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
@@ -1743,7 +1723,6 @@ dependencies = [
 "checksum untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "55cd1f4b4e96b46aeb8d4855db4a7a9bd96eeeb5c6a1ab54593328761642ce2f"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
-"checksum uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e1436e58182935dcd9ce0add9ea0b558e8a87befe01c1a301e6020aeb0876363"
 "checksum uuid 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dab5c5526c5caa3d106653401a267fed923e7046f35895ffcb5ca42db64942e6"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ chrono = { version = "^0.4", features = ["serde"] }
 ctrlc = "^3.1.1"
 futures = "*"
 lazy_static = "^1.2.0"
-listenfd = "^0.3"
 maxminddb = "^0.11.0"
 serde = "^1.0.80"
 serde_derive = "^1.0.80"

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,6 @@
 use actix_web::{http, App, HttpRequest, HttpResponse};
 use chrono::{DateTime, Utc};
 use futures::Future;
-use listenfd::ListenFd;
 use maxminddb::{self, geoip2, MaxMindDBError};
 use serde::Serializer;
 use serde_derive::Serialize;
@@ -40,32 +39,21 @@ fn main() {
         GeoIpActor { reader }
     });
 
+    let host = env::var("HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
+    let port = env::var("PORT").unwrap_or_else(|_| "8080".to_string());
+    let addr = format!("{}:{}", host, port);
+
     let server = actix_web::server::new(move || {
         App::with_state(State {
             geoip: geoip.clone(),
         })
         .resource("/", |r| r.get().f(index))
-    });
-
-    // Re-use a passed file descriptor, or create a new one to listen on.
-    let mut listenfd = ListenFd::from_env();
-    let server = if let Some(listener) = listenfd
-        .take_tcp_listener(0)
-        .expect("Could not get TCP listener")
-    {
-        println!("started server on re-used file descriptor");
-        server.listen(listener)
-    } else {
-        let host = env::var("HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
-        let port = env::var("PORT").unwrap_or_else(|_| "8080".to_string());
-        let addr = format!("{}:{}", host, port);
-        println!("started server on https://{}:{}", host, port);
-        server
-            .bind(&addr)
-            .unwrap_or_else(|err| panic!(format!("Couldn't listen on {}: {}", &addr, err)))
-    };
+    })
+    .bind(&addr)
+    .unwrap_or_else(|err| panic!(format!("Couldn't listen on {}: {}", &addr, err)));
 
     server.start();
+    println!("started server on https://{}:{}", host, port);
     sys.run();
 }
 


### PR DESCRIPTION
Actix-web can re-use a file descriptor instead of listening to a new port, which is used to hot-reload servers. In practice we aren't using that, and it makes things a little messy. In the interest of fewer dependencies and simpler code, I think we should remove it.