### PR TITLE
Don't run rust check in CI, so that clippy actually works

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,6 @@ jobs:
             rustup component add rustfmt
             rustup component add clippy
       - run:
-          name: Check
-          command: cargo check --all-targets --all-features
-      - run:
           name: Rustfmt
           command: cargo fmt -- --check
       - run:


### PR DESCRIPTION
A couple commits lately have landed with clippy problems, since it didn't actually check anything in CI. I expect this will cause some failures, which I'll fix in this PR.

See also https://github.com/rust-lang/rust-clippy/issues/2604.