### PR TITLE
Add coverage reports using codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,7 @@
-version: 2
+version: 2.1
+
+orbs:
+  codecov: codecov/codecov@1.0.1
 
 jobs:
   build:
@@ -11,6 +14,16 @@ jobs:
           command: |
             rustup component add rustfmt
             rustup component add clippy
+            # cargo-kcov needs kcov >= 30. Debian as kcov 11, so these steps
+            # build kcov directly.
+            apt-get update
+            apt-get upgrade -y
+            apt-get install -y cmake g++ pkg-config jq libcurl4-openssl-dev libelf-dev libdw-dev binutils-dev libiberty-dev
+            cargo install cargo-kcov
+            mkdir -p /tmp/kcov
+            pushd /tmp/kcov
+            cargo kcov --print-install-kcov-sh | sh
+            popd
       - run:
           name: Rustfmt
           command: cargo fmt -- --check
@@ -33,3 +46,9 @@ jobs:
             "$CIRCLE_PROJECT_USERNAME" \
             "$CIRCLE_PROJECT_REPONAME" \
             "$CIRCLE_BUILD_URL" > version.json
+      - run:
+          name: Coverage
+          command: cargo kcov
+      - codecov/upload:
+          file: target/cov/
+          flags: flags cargo_kcov

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Classify Client
 
+ [![codecov](https://codecov.io/gh/mozilla/classify-client/branch/master/graph/badge.svg)](https://codecov.io/gh/mozilla/classify-client)
+
 This is an optimized version of the classify client endpoint in [Normandy](https://github.com/mozilla/normandy).
 
 ## Dev instructions


### PR DESCRIPTION
I chose codecov.io because there is an [CircleCI orb](https://circleci.com/docs/2.0/orb-intro/) that makes it very easy to  upload coverage. Most of the work here is getting the coverage tools installed. I plan to move this into mozilla/ci-docker-bases soon so we don't have to duplicate work every time.

Another note is that coverage requires a complete rebuild of the code (to add coverage instrumentation). After this lands and we start getting reports, I want to make CI only build the project once, or parallelize the coverage build.