### PR TITLE
Support path used by normandy

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,7 @@ fn main() -> Result<(), ClassifyError> {
             .middleware(request_log.clone())
             // API Endpoints
             .resource("/", |r| r.get().f(classify::classify_client))
+            .resource("/api/v1/classify_client/", |r| r.get().f(classify::classify_client))
             // Dockerflow Endpoints
             .resource("/__lbheartbeat__", |r| r.get().f(dockerflow::lbheartbeat))
             .resource("/__heartbeat__", |r| r.get().f(dockerflow::heartbeat))

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,9 @@ fn main() -> Result<(), ClassifyError> {
             .middleware(request_log.clone())
             // API Endpoints
             .resource("/", |r| r.get().f(classify::classify_client))
-            .resource("/api/v1/classify_client/", |r| r.get().f(classify::classify_client))
+            .resource("/api/v1/classify_client/", |r| {
+                r.get().f(classify::classify_client)
+            })
             // Dockerflow Endpoints
             .resource("/__lbheartbeat__", |r| r.get().f(dockerflow::lbheartbeat))
             .resource("/__heartbeat__", |r| r.get().f(dockerflow::heartbeat))


### PR DESCRIPTION
Closes #1 

```
$ ./target/release/classify-client
{"Logger":"classify-client-0.1.0","Type":"app","Pid":53803,"Severity":6,"Timestamp":1545429223825160000,"Fields":{"msg":"started server on https://[::]:8080"}}
{"Logger":"classify-client-0.1.0","Type":"request.summary","Pid":53803,"Severity":6,"Timestamp":1545429236252773000,"Fields":{"msg":"","agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:66.0) Gecko/20100101 Firefox/66.0","lang":"en-US,en;q=0.5","remoteAddressChain":"[::1]:62243","path":"/api/v1/classify_client/","method":"GET","code":200}}
```