### PR TITLE
Fix missed clippy problems

### DIFF
--- a/src/endpoints/dockerflow.rs
+++ b/src/endpoints/dockerflow.rs
@@ -73,7 +73,7 @@ mod tests {
 
     #[test]
     fn heartbeat() {
-        let mut srv = test::TestServer::build_with_state(|| EndpointState::default())
+        let mut srv = test::TestServer::build_with_state(EndpointState::default)
             .start(|app| app.handler(&super::heartbeat));
         let req = srv.get().finish().unwrap();
         let resp = srv.execute(req.send()).unwrap();
@@ -82,7 +82,7 @@ mod tests {
 
     #[test]
     fn version() {
-        let mut srv = test::TestServer::build_with_state(|| EndpointState::default())
+        let mut srv = test::TestServer::build_with_state(EndpointState::default)
             .start(|app| app.handler(&super::version));
         let req = srv.get().finish().unwrap();
         let resp = srv.execute(req.send()).unwrap();


### PR DESCRIPTION
We missed these because CircleCI didn't run on #32. It didn't run because that PR came from a fork, which CircleCI had been instructed to ignore. I've turned on running CI from forks, and additionally made checks mandatory for merges.