### PR TITLE
Update coverage badge to where the results are

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Classify Client
 
- [![codecov](https://codecov.io/gh/mozilla/classify-client/branch/master/graph/badge.svg)](https://codecov.io/gh/mozilla/classify-client)
+ [![codecov](https://codecov.io/gh/mozilla/classify-client/branch/staging/graph/badge.svg)](https://codecov.io/gh/mozilla/classify-client)
 
 This is an optimized version of the classify client endpoint in [Normandy](https://github.com/mozilla/normandy).
 


### PR DESCRIPTION
All of our CI coverage for the master branch is being reported for the staging branch that bors uses. This make it so the badge at least shows an accurate value. We should figure out how to make the master branch show correctly, however.