### PR TITLE
Make main a bit leaner

### DIFF
--- a/src/endpoints/classify.rs
+++ b/src/endpoints/classify.rs
@@ -82,7 +82,7 @@ pub fn classify_client(
 
 #[cfg(test)]
 mod tests {
-    use crate::{endpoints::EndpointState, geoip::GeoIpActor, settings::Settings};
+    use crate::{endpoints::EndpointState, geoip::GeoIpActor};
     use actix_web::{http, test, HttpMessage};
     use chrono::DateTime;
     use maxminddb::geoip2;
@@ -124,10 +124,7 @@ mod tests {
                     GeoIpActor::builder().path(&path).build().unwrap()
                 })
             },
-            settings: Settings {
-                trusted_proxy_list: vec!["127.0.0.1/32".parse().unwrap()],
-                ..Settings::default()
-            },
+            trusted_proxies: vec!["127.0.0.1/32".parse().unwrap()],
             ..EndpointState::default()
         })
         .start(|app| app.handler(&super::classify_client));

--- a/src/endpoints/debug.rs
+++ b/src/endpoints/debug.rs
@@ -4,16 +4,16 @@ use crate::{endpoints::EndpointState, utils::RequestClientIp};
 
 /// Show debugging information about the server comprising:
 ///
-///  * Server settings
+///  * Request state,
 ///  * Current request's headers
 ///  * Calculated client IP for the current request
 ///
 /// This handler should be disabled in production servers.
 pub fn debug_handler(req: &HttpRequest<EndpointState>) -> HttpResponse {
     HttpResponse::Ok().body(format!(
-        "received headers: {:?}\n\nsettings: {:?}\n\nclient ip: {:?}",
+        "received headers: {:?}\n\nrequest state: {:?}\n\nclient ip: {:?}",
         req.headers(),
-        &req.state().settings,
+        &req.state(),
         req.client_ip()
     ))
 }

--- a/src/endpoints/dockerflow.rs
+++ b/src/endpoints/dockerflow.rs
@@ -46,7 +46,7 @@ pub fn heartbeat(req: &HttpRequest<EndpointState>) -> FutureResponse<HttpRespons
 }
 
 pub fn version(req: &HttpRequest<EndpointState>) -> HttpResponse {
-    let version_file = &req.state().settings.version_file;
+    let version_file = &req.state().version_file;
     // Read the file or deliberately fail with a 500 if missing.
     let mut file = File::open(version_file).unwrap();
     let mut data = String::new();
@@ -58,8 +58,6 @@ pub fn version(req: &HttpRequest<EndpointState>) -> HttpResponse {
 
 #[cfg(test)]
 mod tests {
-    use std;
-
     use crate::endpoints::EndpointState;
     use actix_web::{http, test};
 

--- a/src/endpoints/mod.rs
+++ b/src/endpoints/mod.rs
@@ -2,25 +2,27 @@ pub mod classify;
 pub mod debug;
 pub mod dockerflow;
 
-use std::default::Default;
+use std::{default::Default, path::PathBuf};
 
-use crate::{geoip::GeoIpActor, settings::Settings, APP_NAME};
+use crate::{geoip::GeoIpActor, APP_NAME};
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct EndpointState {
     pub geoip: actix::Addr<GeoIpActor>,
-    pub settings: Settings,
+    pub trusted_proxies: Vec<ipnet::IpNet>,
     pub log: slog::Logger,
     pub metrics: cadence::StatsdClient,
+    pub version_file: PathBuf,
 }
 
 impl Default for EndpointState {
     fn default() -> Self {
         EndpointState {
-            settings: Settings::default(),
+            trusted_proxies: Vec::default(),
             geoip: actix::SyncArbiter::start(1, GeoIpActor::default),
-            log: slog::Logger::root(slog::Discard, slog::o!()).new(slog::o!()),
+            log: slog::Logger::root(slog::Discard, slog::o!()),
             metrics: cadence::StatsdClient::from_sink(APP_NAME, cadence::NopMetricSink),
+            version_file: "./version.json".into(),
         }
     }
 }

--- a/src/endpoints/mod.rs
+++ b/src/endpoints/mod.rs
@@ -4,13 +4,13 @@ pub mod dockerflow;
 
 use std::default::Default;
 
-use crate::{geoip::GeoIpActor, logging::MozLogger, settings::Settings, APP_NAME};
+use crate::{geoip::GeoIpActor, settings::Settings, APP_NAME};
 
 #[derive(Clone)]
 pub struct EndpointState {
     pub geoip: actix::Addr<GeoIpActor>,
     pub settings: Settings,
-    pub log: MozLogger,
+    pub log: slog::Logger,
     pub metrics: cadence::StatsdClient,
 }
 
@@ -19,7 +19,7 @@ impl Default for EndpointState {
         EndpointState {
             settings: Settings::default(),
             geoip: actix::SyncArbiter::start(1, GeoIpActor::default),
-            log: MozLogger::default(),
+            log: slog::Logger::root(slog::Discard, slog::o!()).new(slog::o!()),
             metrics: cadence::StatsdClient::from_sink(APP_NAME, cadence::NopMetricSink),
         }
     }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,5 +1,6 @@
 use std::io;
 
+use crate::settings::Settings;
 use actix_web::middleware::{Finished, Middleware, Started};
 use actix_web::{HttpRequest, HttpResponse, Result};
 use slog::{self, Drain};
@@ -8,37 +9,26 @@ use slog_derive::KV;
 use slog_mozlog_json::MozLogJson;
 use slog_term;
 
-#[derive(Clone, Debug)]
-pub struct MozLogger {
-    pub log: slog::Logger,
-}
-
-impl MozLogger {
-    pub fn new_json(msg_type: &str) -> Self {
-        let json_drain = MozLogJson::new(io::stdout())
+pub fn get_logger<S: Into<String>>(prefix: S, settings: &Settings) -> slog::Logger {
+    let prefix = prefix.into();
+    let drain = if settings.human_logs {
+        let decorator = slog_term::TermDecorator::new().build();
+        let drain = slog_term::CompactFormat::new(decorator).build().fuse();
+        slog_async::Async::new(drain).build().fuse()
+    } else {
+        let drain = MozLogJson::new(io::stdout())
             .logger_name(format!(
                 "{}-{}",
                 env!("CARGO_PKG_NAME"),
                 env!("CARGO_PKG_VERSION")
             ))
-            .msg_type(msg_type.to_string())
+            .msg_type(prefix)
             .build()
             .fuse();
-        let drain = slog_async::Async::new(json_drain).build().fuse();
-        Self {
-            log: slog::Logger::root(drain, slog::o!()).new(slog::o!()),
-        }
-    }
+        slog_async::Async::new(drain).build().fuse()
+    };
 
-    pub fn new_human() -> Self {
-        let decorator = slog_term::TermDecorator::new().build();
-        let drain = slog_term::CompactFormat::new(decorator).build().fuse();
-        let drain = slog_async::Async::new(drain).build().fuse();
-
-        Self {
-            log: slog::Logger::root(drain, slog::o!()).new(slog::o!()),
-        }
-    }
+    slog::Logger::root(drain, slog::o!()).new(slog::o!())
 }
 
 #[derive(KV)]
@@ -51,7 +41,19 @@ struct MozLogFields {
     lang: Option<String>,
 }
 
-impl<S> Middleware<S> for MozLogger {
+pub struct RequestLogMiddleware {
+    log: slog::Logger,
+}
+
+impl RequestLogMiddleware {
+    pub fn new(settings: &Settings) -> Self {
+        RequestLogMiddleware {
+            log: get_logger("request.summary", settings),
+        }
+    }
+}
+
+impl<S> Middleware<S> for RequestLogMiddleware {
     fn start(&self, _req: &HttpRequest<S>) -> Result<Started> {
         Ok(Started::Done)
     }
@@ -74,13 +76,5 @@ impl<S> Middleware<S> for MozLogger {
         };
         slog::info!(self.log, "" ; slog::o!(fields));
         Finished::Done
-    }
-}
-
-impl Default for MozLogger {
-    fn default() -> Self {
-        Self {
-            log: slog::Logger::root(slog::Discard, slog::o!()).new(slog::o!()),
-        }
     }
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,6 +1,5 @@
 use std::io;
 
-use crate::settings::Settings;
 use actix_web::middleware::{Finished, Middleware, Started};
 use actix_web::{HttpRequest, HttpResponse, Result};
 use slog::{self, Drain};
@@ -9,9 +8,9 @@ use slog_derive::KV;
 use slog_mozlog_json::MozLogJson;
 use slog_term;
 
-pub fn get_logger<S: Into<String>>(prefix: S, settings: &Settings) -> slog::Logger {
+pub fn get_logger<S: Into<String>>(prefix: S, human_logs: bool) -> slog::Logger {
     let prefix = prefix.into();
-    let drain = if settings.human_logs {
+    let drain = if human_logs {
         let decorator = slog_term::TermDecorator::new().build();
         let drain = slog_term::CompactFormat::new(decorator).build().fuse();
         slog_async::Async::new(drain).build().fuse()
@@ -28,7 +27,7 @@ pub fn get_logger<S: Into<String>>(prefix: S, settings: &Settings) -> slog::Logg
         slog_async::Async::new(drain).build().fuse()
     };
 
-    slog::Logger::root(drain, slog::o!()).new(slog::o!())
+    slog::Logger::root(drain, slog::o!())
 }
 
 #[derive(KV)]
@@ -46,9 +45,9 @@ pub struct RequestLogMiddleware {
 }
 
 impl RequestLogMiddleware {
-    pub fn new(settings: &Settings) -> Self {
+    pub fn new(human_logs: bool) -> Self {
         RequestLogMiddleware {
-            log: get_logger("request.summary", settings),
+            log: get_logger("request.summary", human_logs),
         }
     }
 }


### PR DESCRIPTION
I'm not confident about this change. I wanted to try and make `main` a bit smaller and more direct. To that end, I re-used the pattern I used for the metrics builder, and logging and geoip to use methods that take a settings object and return the right thing, instead of putting that logic in `main`. I also refactored logging to accommodate that.

@leplatrem I'd like feedback here about what you think of these changes, and about this pattern overall. If it is something we'd like to push forward with, I'll fix up the merge conflict and we can land it. I'd also be fine closing this PR unmerged.