### PR TITLE
Remove required reviews from bors

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,4 +1,3 @@
 status = ["ci/circleci: build", "ci/circleci: test"]
 block_labels = ["bors-dont-merge"]
-required_approvals = 1
 delete_merged_branches = true


### PR DESCRIPTION
We removed this from other Product Delivery products because it ended up being annoying. I forgot to change this one.