### PR TITLE
Disable renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "config:base"
-  ]
-}


### PR DESCRIPTION
Classify Client is essentially in maintenance mode, and doesn't need regular dependency updates.