### PR TITLE
Fix app_data access, which I broke in the Actix Web 4 upgrade.

### DIFF
--- a/src/endpoints/debug.rs
+++ b/src/endpoints/debug.rs
@@ -1,5 +1,5 @@
 use crate::{endpoints::EndpointState, utils::RequestClientIp};
-use actix_web::{HttpRequest, HttpResponse};
+use actix_web::{web::Data, HttpRequest, HttpResponse};
 
 /// Show debugging information about the server comprising:
 ///
@@ -8,11 +8,11 @@ use actix_web::{HttpRequest, HttpResponse};
 ///  * Calculated client IP for the current request
 ///
 /// This handler should be disabled in production servers.
-pub async fn debug_handler(req: HttpRequest) -> HttpResponse {
+pub async fn debug_handler(req: HttpRequest, state: Data<EndpointState>) -> HttpResponse {
     HttpResponse::Ok().body(format!(
         "received headers: {:?}\n\nrequest state: {:?}\n\nclient ip: {:?}",
         req.headers(),
-        &req.app_data::<EndpointState>(),
+        state,
         req.client_ip()
     ))
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,5 +1,6 @@
 use actix_web::{
     dev::{Service, ServiceRequest, ServiceResponse, Transform},
+    web::Data,
     Error, HttpRequest, HttpResponse,
 };
 use futures::{future, Future, FutureExt};
@@ -109,7 +110,7 @@ where
     actix_web::dev::forward_ready!(service);
 
     fn call(&self, req: ServiceRequest) -> Self::Future {
-        let log = match req.app_data::<EndpointState>() {
+        let log = match req.app_data::<Data<EndpointState>>() {
             Some(state) => state.log.clone(),
             None => return Box::pin(self.service.call(req)),
         };

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
 use crate::{endpoints::EndpointState, errors::ClassifyError};
-use actix_web::HttpRequest;
+use actix_web::{web::Data, HttpRequest};
 use std::net::IpAddr;
 
 pub trait RequestClientIp<S> {
@@ -20,7 +20,7 @@ pub trait RequestTraceIps<'a> {
 impl RequestClientIp<EndpointState> for HttpRequest {
     fn client_ip(&self) -> Result<IpAddr, ClassifyError> {
         let trusted_proxy_list = &self
-            .app_data::<EndpointState>()
+            .app_data::<Data<EndpointState>>()
             .expect("Expected app state")
             .trusted_proxies;
 
@@ -96,7 +96,7 @@ mod tests {
 
         let req = TestRequest::get()
             .insert_header(("x-forwarded-for", "1.2.3.4, 5.6.7.8"))
-            .app_data(state)
+            .app_data(Data::new(state))
             .to_http_request();
 
         assert_eq!(
@@ -118,7 +118,7 @@ mod tests {
 
         let req = TestRequest::get()
             .insert_header(("x-forwarded-for", "1.2.3.4, 5.6.7.8"))
-            .app_data(state)
+            .app_data(Data::new(state))
             .to_http_request();
 
         assert_eq!(
@@ -140,7 +140,7 @@ mod tests {
 
         let req = TestRequest::get()
             .insert_header(("x-forwarded-for", "1.2.3.4, 5.6.7.8"))
-            .app_data(state)
+            .app_data(Data::new(state))
             .to_http_request();
 
         assert!(


### PR DESCRIPTION
Accessing application state changed in Actix Web 4, and I implemented the changes in #123 only incompletely. With this change, we always use the `Data` wrapper for the endpoint state, which fixes the problem.