### PR TITLE
Moved API key loading/caching to startup. Added error logs and tests.

### DIFF
--- a/src/endpoints/mod.rs
+++ b/src/endpoints/mod.rs
@@ -4,10 +4,11 @@ pub mod country;
 pub mod debug;
 pub mod dockerflow;
 use crate::{geoip::GeoIp, APP_NAME};
-use std::{default::Default, path::PathBuf, sync::Arc};
+use std::{collections::HashSet, default::Default, path::PathBuf, sync::Arc};
 
 #[derive(Clone, Debug)]
 pub struct EndpointState {
+    pub api_keys_hashset: HashSet<String>,
     pub geoip: Arc<GeoIp>,
     pub trusted_proxies: Vec<ipnet::IpNet>,
     pub log: slog::Logger,
@@ -18,6 +19,7 @@ pub struct EndpointState {
 impl Default for EndpointState {
     fn default() -> Self {
         EndpointState {
+            api_keys_hashset: HashSet::new(),
             trusted_proxies: Vec::default(),
             geoip: Arc::new(GeoIp::default()),
             log: slog::Logger::root(slog::Discard, slog::o!()),

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,0 +1,102 @@
+use serde_json::{from_str, Value};
+use slog::Logger;
+use std::collections::HashSet;
+use std::fs::read_to_string;
+use std::path::PathBuf;
+
+pub fn load(file_path: PathBuf, app_log: Logger) -> HashSet<String> {
+    let mut keys: HashSet<String> = HashSet::new();
+
+    match read_to_string(file_path) {
+        Ok(contents) => match from_str::<Value>(&contents) {
+            Ok(json_value) => {
+                if let Some(array) = json_value.as_array() {
+                    for item in array {
+                        if let Value::String(string) = &item {
+                            keys.insert(string.to_string());
+                        }
+                    }
+                }
+            }
+            Err(err) => {
+                slog::error!(app_log, "Error parsing api keys file. {}", err)
+            }
+        },
+        Err(err) => {
+            slog::error!(app_log, "Error reading api keys file. {}", err)
+        }
+    }
+
+    return keys;
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::keys::load;
+    use slog::Drain;
+    use slog::{OwnedKVList, Record};
+    use std::{
+        fs,
+        path::PathBuf,
+        sync::{Arc, Mutex},
+    };
+
+    struct VecDrain {
+        logs: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl Drain for VecDrain {
+        type Ok = ();
+        type Err = slog::Never;
+
+        fn log(&self, record: &Record, _values: &OwnedKVList) -> Result<Self::Ok, Self::Err> {
+            if let Ok(mut logs) = self.logs.lock() {
+                logs.push(record.level().to_string() + " / " + &record.msg().to_string());
+            }
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_load() {
+        // setup
+        let logs = Arc::new(Mutex::new(Vec::new()));
+        let logger =
+            slog::Logger::root(slog::Fuse::new(VecDrain { logs: logs.clone() }), slog::o!());
+
+        let missing_file: PathBuf = "./missing_file.json".into();
+        let corrupt_file: PathBuf = "./corrupt_file.json".into();
+        let good_file: PathBuf = "./good_file.json".into();
+
+        let _ = fs::remove_file(missing_file.clone());
+        let _ = fs::write(corrupt_file.clone(), "[\"foo\"]z");
+        let _ = fs::write(good_file.clone(), "[\"foo\"]");
+
+        // tests
+        let missing_set = load(missing_file.clone(), logger.clone());
+        assert!(missing_set.len() == 0);
+        assert!(logs
+            .lock()
+            .unwrap()
+            .pop()
+            .unwrap()
+            .starts_with("ERRO / Error reading api keys file"));
+
+        let corrupt_set = load(corrupt_file.clone(), logger.clone());
+        assert!(corrupt_set.len() == 0);
+        assert!(logs
+            .lock()
+            .unwrap()
+            .pop()
+            .unwrap()
+            .starts_with("ERRO / Error parsing api keys file"));
+
+        let good_set = load(good_file.clone(), logger.clone());
+        assert!(good_set.len() == 1);
+        assert!(logs.lock().unwrap().pop() == None);
+
+        // cleanup
+        let _ = fs::remove_file(corrupt_file);
+        let _ = fs::remove_file(good_file);
+    }
+}

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -27,7 +27,7 @@ pub fn load(file_path: PathBuf, app_log: Logger) -> HashSet<String> {
         }
     }
 
-    return keys;
+    keys
 }
 
 #[cfg(test)]
@@ -74,7 +74,7 @@ mod tests {
 
         // tests
         let missing_set = load(missing_file.clone(), logger.clone());
-        assert!(missing_set.len() == 0);
+        assert!(missing_set.is_empty());
         assert!(logs
             .lock()
             .unwrap()
@@ -83,7 +83,7 @@ mod tests {
             .starts_with("ERRO / Error reading api keys file"));
 
         let corrupt_set = load(corrupt_file.clone(), logger.clone());
-        assert!(corrupt_set.len() == 0);
+        assert!(corrupt_set.is_empty());
         assert!(logs
             .lock()
             .unwrap()
@@ -93,7 +93,7 @@ mod tests {
 
         let good_set = load(good_file.clone(), logger.clone());
         assert!(good_set.len() == 1);
-        assert!(logs.lock().unwrap().pop() == None);
+        assert!(logs.lock().unwrap().pop().is_none());
 
         // cleanup
         let _ = fs::remove_file(corrupt_file);

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 pub mod endpoints;
 pub mod errors;
 pub mod geoip;
+pub mod keys;
 pub mod logging;
 pub mod metrics;
 pub mod settings;
@@ -27,6 +28,7 @@ const APP_NAME: &str = "classify-client";
 #[actix_web::main]
 async fn main() -> Result<(), ClassifyError> {
     let Settings {
+        api_keys_file,
         debug,
         geoip_db_path,
         host,
@@ -59,6 +61,7 @@ async fn main() -> Result<(), ClassifyError> {
     ));
 
     let state = EndpointState {
+        api_keys_hashset: keys::load(api_keys_file, app_log.clone()),
         geoip: Arc::new(
             GeoIp::builder()
                 .path(geoip_db_path)


### PR DESCRIPTION
This is a followup from #152 . 

- Moved API key file loading to startup rather than lazy loading.
- Added error logging for if the api keys file is missing or cannot be parsed.
- Added test scenarios to verify logging worked as expected.