### PR TITLE
/v1/country endpoint should handle all verbs, as ichnea did

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -90,6 +90,7 @@ async fn main() -> Result<(), ClassifyError> {
                     .route(web::get().to(classify::classify_client)),
             )
             .service(web::resource("/v1/country").route(web::get().to(country::get_country)))
+            .service(web::resource("/v1/country").route(web::post().to(country::get_country)))
             // Dockerflow Endpoints
             .service(
                 web::resource("/__lbheartbeat__").route(web::get().to(dockerflow::lbheartbeat)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,8 +89,7 @@ async fn main() -> Result<(), ClassifyError> {
                 web::resource("/api/v1/classify_client/")
                     .route(web::get().to(classify::classify_client)),
             )
-            .service(web::resource("/v1/country").route(web::get().to(country::get_country)))
-            .service(web::resource("/v1/country").route(web::post().to(country::get_country)))
+            .service(web::resource("/v1/country").route(web::route().to(country::get_country)))
             // Dockerflow Endpoints
             .service(
                 web::resource("/__lbheartbeat__").route(web::get().to(dockerflow::lbheartbeat)),


### PR DESCRIPTION
Ichnea handled all verbs for /v1/country, routing all verbs in the same way.
Hotfix.