### PR TITLE
Add container image building to this repo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,82 @@
+name: Publish Docker Image
+
+on:
+  # TODO: When classify-client is fully cut over to Argo, remove this
+  # workflow_dispatch trigger
+  workflow_dispatch: {}
+  pull_request:
+    branches:
+      - master
+  # push:
+  #   branches:
+  #     - master
+  #   tags:
+  #     - v[0-9]+.[0-9]+.[0-9]+
+
+jobs:
+  build_image:
+    name: Build and Publish Image
+    runs-on: ubuntu-latest
+    env:
+      GAR_LOCATION: us
+      GAR_REPOSITORY: classify-client-prod
+      GCP_PROJECT_ID: moz-fx-classify-client-pr-09cc
+      IMAGE: classify-client
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - id: checkout-application-repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: build-version-json
+        run: |
+          cd src
+          printf '{\n    "commit": "%s",\n    "version": "%s",\n    "source": "%s",\n    "build": "%s"\n}\n' \
+          "$(git rev-parse --short HEAD)" \
+          "$(git describe --tags --abbrev=4)" \
+          "$(git config --get remote.origin.url)" \
+          "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" > ./version.json
+          # Show complete version.json for debugging
+          cat ./version.json
+
+      - uses: docker/setup-buildx-action@v3
+
+      - id: gcp_auth
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: access_token
+          service_account: artifact-writer@${{ env.GCP_PROJECT_ID }}.iam.gserviceaccount.com
+          workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
+
+      - name: Login to GAR
+        uses: docker/login-action@v3
+        if: ${{ github.event_name != 'pull_request' }}
+        with:
+          registry: ${{ env.GAR_LOCATION }}-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.gcp_auth.outputs.access_token }}
+
+      - id: meta
+        name: generate Docker image metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY }}/${{ env.IMAGE }}
+          # https://github.com/marketplace/actions/docker-metadata-action#tags-input
+          # Every workflow run builds a new `latest` image
+          # Every semver-tagged commit builds a new image tagged with the semver version
+          tags: |
+            type=raw,value=latest
+            type=semver,pattern={{raw}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,6 @@ jobs:
 
       - id: build-version-json
         run: |
-          cd src
           printf '{\n    "commit": "%s",\n    "version": "%s",\n    "source": "%s",\n    "build": "%s"\n}\n' \
           "$(git rev-parse --short HEAD)" \
           "$(git describe --tags --abbrev=4)" \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,7 @@ jobs:
 
       - id: gcp_auth
         uses: google-github-actions/auth@v2
+        if: ${{ github.event_name != 'pull_request' }}
         with:
           token_format: access_token
           service_account: artifact-writer@${{ env.GCP_PROJECT_ID }}.iam.gserviceaccount.com


### PR DESCRIPTION
For now, we only have a `workflow_dispatch` trigger to facilitate manual testing, but when this service is fully migrated to Argo, that trigger will be removed and the image will only be published on commits to `master` and semver tag pushes.

In the future, this workflow will:
- run on every pull request (but not push the image) as a CI step
- publish every commit to `master` as the new `latest` image
- publish every (semver) tagged commit as an image with that same tag and a new `latest` image