### PR TITLE
FDT-21 - updating dependabot schedule to monthly for lighter maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       minor:
         update-types:


### PR DESCRIPTION
Moving to a monthly dependabot schedule.
We tend to only do releases once every month or two anyway.